### PR TITLE
Simplify downloader adapter and update documentation and tests

### DIFF
--- a/04_workdir.yaml
+++ b/04_workdir.yaml
@@ -7,11 +7,12 @@ logging:
             filename: logs/app_go_logger.log
     loggers:
         default:
-            level: DEBUG
+            level: WARNING
+
+        # Logger configuration for each package
         pkg_infra:
             level: INFO
-            handlers: [file, console]
-            propagate: false
+
         download_manager:
             level: INFO
             handlers: [file, console]
@@ -30,6 +31,7 @@ integrations:  # New question: store the big yaml?
         settings:
         -   enabled: true # This will be switch <--- what should be the default value?
         -   cache_path: ontograph_config.yaml
+        -   downloader: download_manager
         -   source_ontology: chebi
         -   backend: graphblas
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ from ontograph.config.settings import DEFAULT_CACHE_DIR
 # Instantiate a client for your catalog
 client_catalog = ClientCatalog(cache_dir="./data/out")
 
-# Optional: choose a downloader adapter explicitly
+# Optional: choose downloader via string or adapter (client-level only)
+# client_catalog = ClientCatalog(cache_dir="./data/out", downloader="download_manager")
 # downloader = DownloadManagerAdapter(cache_dir=DEFAULT_CACHE_DIR, backend="requests")
 # client_catalog = ClientCatalog(cache_dir="./data/out", downloader=downloader)
 
@@ -71,7 +72,8 @@ client_dummy_ontology = ClientOntology(cache_dir="./data/out")
 # Load a dummy ontology, we prepare a simple one to try out this package.
 client_dummy_ontology.load(source="./tests/resources/dummy_ontology.obo")
 
-# Optional: choose a downloader adapter explicitly
+# Optional: choose downloader via string or adapter (client-level only)
+# client_dummy_ontology = ClientOntology(cache_dir="./data/out", downloader="pooch")
 # downloader = DownloadManagerAdapter(cache_dir=DEFAULT_CACHE_DIR, backend="requests")
 # client_dummy_ontology = ClientOntology(cache_dir="./data/out", downloader=downloader)
 ```
@@ -158,6 +160,7 @@ client_go.load(source="go")
 By default, the project uses a configurable downloader backend. You can set a global default in `ontograph/config/settings.py`:
 
 ```python
+# Used as the fallback when no downloader is provided
 DEFAULT_DOWNLOADER = "pooch"
 # or
 DEFAULT_DOWNLOADER = "download_manager"

--- a/docs/learn/tutorials/quickstart.md
+++ b/docs/learn/tutorials/quickstart.md
@@ -20,7 +20,8 @@ client_catalog = ClientCatalog(cache_dir="./data/out")
 # Load the catalog (downloads if not cached)
 client_catalog.load_catalog()
 
-# Optional: choose a downloader adapter explicitly
+# Optional: choose downloader via string or adapter (client-level only)
+# client_catalog = ClientCatalog(cache_dir="./data/out", downloader="download_manager")
 # downloader = DownloadManagerAdapter(cache_dir=DEFAULT_CACHE_DIR, backend="requests")
 # client_catalog = ClientCatalog(cache_dir="./data/out", downloader=downloader)
 ```
@@ -63,7 +64,8 @@ client_ontology = ClientOntology(cache_dir="./data/out")
 # Load a sample ontology (provided in the repo for testing)
 client_ontology.load(source="./tests/resources/dummy_ontology.obo")
 
-# Optional: choose a downloader adapter explicitly
+# Optional: choose downloader via string or adapter (client-level only)
+# client_ontology = ClientOntology(cache_dir="./data/out", downloader="pooch")
 # downloader = DownloadManagerAdapter(cache_dir=DEFAULT_CACHE_DIR, backend="requests")
 # client_ontology = ClientOntology(cache_dir="./data/out", downloader=downloader)
 ```

--- a/docs/learn/tutorials/tutorial0001_basics.md
+++ b/docs/learn/tutorials/tutorial0001_basics.md
@@ -15,6 +15,7 @@ DEFAULT_DOWNLOADER = "download_manager"
 ```
 
 Now any client will use the configured backend unless you pass a downloader explicitly.
+Only client classes accept backend strings; lower-level components expect a downloader adapter instance.
 
 ---
 

--- a/docs/reference/source/ontograph/client-catalog.md
+++ b/docs/reference/source/ontograph/client-catalog.md
@@ -24,7 +24,9 @@ from ontograph.config.settings import DEFAULT_CACHE_DIR
 
 client_catalog = ClientCatalog(cache_dir="./data/out")
 
-# Optional: use Download Manager for all catalog downloads
+# Optional: use a backend string (client-level only)
+# client_catalog = ClientCatalog(cache_dir="./data/out", downloader="download_manager")
+# Or pass the adapter explicitly
 # downloader = DownloadManagerAdapter(cache_dir=DEFAULT_CACHE_DIR, backend="requests")
 # client_catalog = ClientCatalog(cache_dir="./data/out", downloader=downloader)
 ```

--- a/docs/reference/source/ontograph/client-ontology.md
+++ b/docs/reference/source/ontograph/client-ontology.md
@@ -24,7 +24,9 @@ from ontograph.config.settings import DEFAULT_CACHE_DIR
 
 client_ontology = ClientOntology(cache_dir="./data/out")
 
-# Optional: use Download Manager for all remote downloads
+# Optional: use a backend string (client-level only)
+# client_ontology = ClientOntology(cache_dir="./data/out", downloader="pooch")
+# Or pass the adapter explicitly
 # downloader = DownloadManagerAdapter(cache_dir=DEFAULT_CACHE_DIR, backend="requests")
 # client_ontology = ClientOntology(cache_dir="./data/out", downloader=downloader)
 ```

--- a/docs/reference/source/ontograph/downloader.md
+++ b/docs/reference/source/ontograph/downloader.md
@@ -15,6 +15,10 @@ from ontograph.config.settings import DEFAULT_CACHE_DIR
 downloader = get_default_downloader(cache_dir=DEFAULT_CACHE_DIR)
 ```
 
+Note: String backends (e.g., `"pooch"`, `"download_manager"`) are accepted
+at the client layer (`ClientCatalog` / `ClientOntology`). Lower-level
+components expect a downloader adapter instance.
+
 ---
 
 ## API Reference

--- a/ontograph/client.py
+++ b/ontograph/client.py
@@ -33,7 +33,7 @@ from ontograph.models import (
     NodesDataframe,
     CatalogOntologies,
 )
-from ontograph.downloader import DownloaderPort
+from ontograph.downloader import DownloaderPort, get_default_downloader
 from ontograph.config.settings import DEFAULT_CACHE_DIR
 from ontograph.queries.navigator import (
     NavigatorPronto,
@@ -58,6 +58,16 @@ __all__ = [
 ]
 
 
+def _resolve_downloader(
+    cache_dir: Path, downloader: DownloaderPort | str | None
+) -> DownloaderPort:
+    if isinstance(downloader, str):
+        return get_default_downloader(cache_dir=cache_dir, backend=downloader)
+    if downloader is None:
+        return get_default_downloader(cache_dir=cache_dir, backend='pooch')
+    return downloader
+
+
 # --------------------------------------------- #
 # ----          Client for Catalog          --- #
 # --------------------------------------------- #
@@ -76,19 +86,22 @@ class ClientCatalog:
     def __init__(
         self,
         cache_dir: str = DEFAULT_CACHE_DIR,
-        downloader: DownloaderPort | None = None,
+        downloader: DownloaderPort | str | None = None,
     ) -> None:
         """Initialize the ClientCatalog.
 
         Args:
             cache_dir (str, optional): Directory for caching catalog data. Defaults to DEFAULT_CACHE_DIR.
-            downloader (DownloaderPort | None, optional): Downloader adapter for remote resources. Defaults to None.
+            downloader (DownloaderPort | str | None, optional): Downloader adapter or backend name
+                ('pooch' or 'download_manager'). Defaults to 'pooch'.
         """
+        cache_path = Path(cache_dir)
+        resolved_downloader = _resolve_downloader(cache_path, downloader)
         self.__catalog_adapter = CatalogOntologies(
-            cache_dir=Path(cache_dir),
-            downloader=downloader,
+            cache_dir=cache_path,
+            downloader=resolved_downloader,
         )
-        self._downloader = downloader
+        self._downloader = resolved_downloader
 
     def load_catalog(self, force_download: bool = False) -> None:
         """Load the ontology catalog.
@@ -231,17 +244,18 @@ class ClientOntology:
     def __init__(
         self,
         cache_dir: str = DEFAULT_CACHE_DIR,
-        downloader: DownloaderPort | None = None,
+        downloader: DownloaderPort | str | None = None,
     ) -> None:
         """Initialize the ClientOntology.
 
         Args:
             cache_dir (str, optional): Directory for caching ontology data. Defaults to DEFAULT_CACHE_DIR.
-            downloader (DownloaderPort | None, optional): Downloader adapter for remote resources. Defaults to None.
+            downloader (DownloaderPort | str | None, optional): Downloader adapter or backend name
+                ('pooch' or 'download_manager'). Defaults to 'pooch'.
         """
         self._cache_dir = Path(cache_dir)
+        self._downloader = _resolve_downloader(self._cache_dir, downloader)
         self._ontology = None
-        self._downloader = downloader
         self._lookup_tables = None
         self._navigator = None
         self._relations = None
@@ -331,7 +345,7 @@ class ClientOntology:
     def load(
         self,
         source: str,
-        downloader: DownloaderPort = None,
+        downloader: DownloaderPort | str | None = None,
         include_obsolete: bool = False,
         backend: str = 'pronto',
     ) -> None:
@@ -346,7 +360,8 @@ class ClientOntology:
 
         Args:
             source (str): Path to the ontology file, URL, or OBO Foundry identifier.
-            downloader (DownloaderPort, optional): Downloader adapter for remote files. Defaults to None.
+            downloader (DownloaderPort | str | None, optional): Downloader adapter or backend name
+                ('pooch' or 'download_manager'). Defaults to None.
             include_obsolete (bool, optional): If True, include obsolete terms when building GraphBLAS structures. Defaults to False.
             backend (str, optional): Backend for queries ('pronto' or 'graphblas'). Defaults to 'pronto'.
 
@@ -362,12 +377,19 @@ class ClientOntology:
             >>> client.load(source="./tests/resources/dummy_ontology.obo")
         """
         logger.info(f'Loading ontology from source: {source} ...')
+        resolved_downloader = (
+            _resolve_downloader(self._cache_dir, downloader)
+            if downloader is not None
+            else self._downloader
+        )
         logger.debug(
             'Using downloader: %s',
-            type(downloader).__name__ if downloader else 'default',
+            type(resolved_downloader).__name__
+            if resolved_downloader
+            else 'default',
         )
         loader = ProntoLoaderAdapter(
-            cache_dir=self._cache_dir, downloader=self._downloader
+            cache_dir=self._cache_dir, downloader=resolved_downloader
         )
 
         path = Path(source)
@@ -388,14 +410,16 @@ class ClientOntology:
                 f'Detected URL source, downloading ontology from {source}'
             )
             filename = Path(source).name or 'ontology.obo'
-            ontology = loader.load_from_url(source, filename, downloader)
+            ontology = loader.load_from_url(
+                source, filename, resolved_downloader
+            )
 
         # 3. Case 3: Try OBO catalog (if file missing or simple ID)
         else:
             logger.debug('Resolved source type: catalog')
             catalog_client = ClientCatalog(
                 cache_dir=self._cache_dir,
-                downloader=self._downloader,
+                downloader=resolved_downloader,
             )
             catalog_client.load_catalog()
             available = [
@@ -410,7 +434,7 @@ class ClientOntology:
                 ontology = loader.load_from_catalog(
                     name_id=name_id,
                     format='obo',
-                    downloader=self._downloader,
+                    downloader=resolved_downloader,
                 )
             else:
                 msg = f"Ontology '{source}' not found as file, URL, or catalog entry."

--- a/ontograph/loader.py
+++ b/ontograph/loader.py
@@ -410,9 +410,7 @@ class ProntoLoaderAdapter(OntologyLoaderPort):
             downloader = self._downloader
         if downloader is None:
             downloader = get_default_downloader(cache_dir=self.cache_dir)
-            logger.debug(
-                f'Created default downloader: {type(downloader).__name__}'
-            )
+        logger.debug(f'Created default downloader: {type(downloader).__name__}')
 
         logger.info(
             'Downloading ontology %s.%s using %s (catalog)',
@@ -520,9 +518,7 @@ class ProntoLoaderAdapter(OntologyLoaderPort):
             downloader = self._downloader
         if downloader is None:
             downloader = get_default_downloader(cache_dir=self.cache_dir)
-            logger.debug(
-                f'Created default downloader: {type(downloader).__name__}'
-            )
+        logger.debug(f'Created default downloader: {type(downloader).__name__}')
 
         logger.info(
             'Downloading ontology from URL using %s: %s',

--- a/sandbox/use_case_downloaders.py
+++ b/sandbox/use_case_downloaders.py
@@ -38,6 +38,10 @@ def main():
     client = ClientOntology(cache_dir=cache_dir, downloader=downloader)
     client.load(source='go')  # catalog download
 
+    # Print roots of GO ontology
+    logger.info("Roots GO ontology: ")
+    logger.info(f"{client.get_root()}")
+
 if __name__ == '__main__':
 
     main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+import ontograph.client as client_module
 
 from ontograph.client import ClientCatalog, ClientOntology
 from ontograph.models import Ontology, TermList
@@ -117,7 +118,7 @@ def test_get_download_url_and_formats(client_catalog):
 
 def test_client_ontology_load_from_file(client_ontology, dummy_ontology_path):
     # Should load ontology from file and initialize queries
-    ontology = client_ontology.load(source=str(dummy_ontology_path))
+    client_ontology.load(source=str(dummy_ontology_path))
     # The new load method does not return ontology, so check internal state
     assert isinstance(client_ontology._ontology, Ontology)
     # Should be able to access root term
@@ -187,3 +188,43 @@ def test_client_ontology_introspection_methods(
     assert isinstance(path, list)
     trajectories = client_ontology.get_trajectories_from_root('D')
     assert isinstance(trajectories, list)
+
+
+def test_client_catalog_downloader_string_uses_backend(tmp_path, monkeypatch):
+    class DummyDownloader:
+        pass
+
+    calls = {}
+
+    def fake_get_default(cache_dir, *, backend=None):
+        calls['cache_dir'] = cache_dir
+        calls['backend'] = backend
+        return DummyDownloader()
+
+    monkeypatch.setattr(
+        client_module, 'get_default_downloader', fake_get_default
+    )
+
+    client = ClientCatalog(cache_dir=tmp_path, downloader='download_manager')
+    assert isinstance(client._downloader, DummyDownloader)
+    assert calls['backend'] == 'download_manager'
+
+
+def test_client_ontology_downloader_string_uses_backend(tmp_path, monkeypatch):
+    class DummyDownloader:
+        pass
+
+    calls = {}
+
+    def fake_get_default(cache_dir, *, backend=None):
+        calls['cache_dir'] = cache_dir
+        calls['backend'] = backend
+        return DummyDownloader()
+
+    monkeypatch.setattr(
+        client_module, 'get_default_downloader', fake_get_default
+    )
+
+    client = ClientOntology(cache_dir=tmp_path, downloader='pooch')
+    assert isinstance(client._downloader, DummyDownloader)
+    assert calls['backend'] == 'pooch'


### PR DESCRIPTION
This pull request introduces improvements to how downloader backends are configured and used in the `ClientCatalog` and `ClientOntology` classes, making it easier to specify downloader adapters via string names or instances. Documentation and tests are updated to reflect and validate these changes. The most important updates are grouped below.

**Downloader backend configuration improvements:**

* Added support for specifying downloader backends as strings (e.g., `"pooch"`, `"download_manager"`) at the client level in `ClientCatalog` and `ClientOntology`. A helper function `_resolve_downloader` handles resolution of string names to adapter instances. [[1]](diffhunk://#diff-bb1e138a47809d0a9372ab3564e85a3ae45c14526a096b2b8a627b465bec1c61R61-R70) [[2]](diffhunk://#diff-bb1e138a47809d0a9372ab3564e85a3ae45c14526a096b2b8a627b465bec1c61L79-R104) [[3]](diffhunk://#diff-bb1e138a47809d0a9372ab3564e85a3ae45c14526a096b2b8a627b465bec1c61L234-L244) [[4]](diffhunk://#diff-bb1e138a47809d0a9372ab3564e85a3ae45c14526a096b2b8a627b465bec1c61L334-R348) [[5]](diffhunk://#diff-bb1e138a47809d0a9372ab3564e85a3ae45c14526a096b2b8a627b465bec1c61L349-R364) [[6]](diffhunk://#diff-bb1e138a47809d0a9372ab3564e85a3ae45c14526a096b2b8a627b465bec1c61R380-R392)
* Updated downloader handling in loader methods to consistently use resolved downloader adapters, ensuring correct behavior when loading from files, URLs, or catalogs. [[1]](diffhunk://#diff-bb1e138a47809d0a9372ab3564e85a3ae45c14526a096b2b8a627b465bec1c61L391-R422) [[2]](diffhunk://#diff-bb1e138a47809d0a9372ab3564e85a3ae45c14526a096b2b8a627b465bec1c61L413-R437) [[3]](diffhunk://#diff-977371f8f0a5b9340085c6f4d577d392c5bc50fd7d969b4629ce3e2215d90b6aL413-R413) [[4]](diffhunk://#diff-977371f8f0a5b9340085c6f4d577d392c5bc50fd7d969b4629ce3e2215d90b6aL523-R521)

**Documentation updates:**

* Revised usage examples and explanations in `README.md`, tutorial, and reference docs to clarify how to specify downloader backends via string or adapter at the client level, and to note that lower-level components require adapter instances. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R40) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-R76) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R163) [[4]](diffhunk://#diff-11da6fbb27b07aa955a032b96b7fad389d74797a0ffd580621af67c83619ef57L23-R24) [[5]](diffhunk://#diff-11da6fbb27b07aa955a032b96b7fad389d74797a0ffd580621af67c83619ef57L66-R68) [[6]](diffhunk://#diff-fe48267b1bbb166d0a8ae426068d7f22d294554ab52989fd8798daa4f10b8f25R18) [[7]](diffhunk://#diff-a8ca085cef4b26e4b7a0d235c6d44efbf2abdae2a5906b2302b0e5d499024142L27-R29) [[8]](diffhunk://#diff-32033fcf64bc551206ab53a801e2f912d88501285b2009928f07289c4020826cL27-R29) [[9]](diffhunk://#diff-9b34f374932006b60ae845e3392f5724fbfac3f65b6d435cf654218a9cc12330R18-R21)

**Testing enhancements:**

* Added tests to verify that passing a string backend to `ClientCatalog` and `ClientOntology` correctly resolves to the intended downloader adapter, using monkeypatching to simulate backend resolution.
* Updated existing tests to reflect changes in the `load` method return values and downloader handling.

**Logging and configuration tweaks:**

* Adjusted logging levels and logger configuration in `04_workdir.yaml` for improved clarity and control.
* Added downloader configuration to integration settings in `04_workdir.yaml`.

**Miscellaneous improvements:**

* Added an example in `sandbox/use_case_downloaders.py` for printing ontology roots after loading.
* Minor import and code organization updates for clarity and maintainability. [[1]](diffhunk://#diff-bb1e138a47809d0a9372ab3564e85a3ae45c14526a096b2b8a627b465bec1c61L36-R36) [[2]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110R4)

These changes collectively make downloader configuration more flexible and user-friendly, and ensure that documentation and tests accurately reflect the new behavior.